### PR TITLE
Add write method that defaults to agent label

### DIFF
--- a/Sources/LaunchAgent/LaunchControl.swift
+++ b/Sources/LaunchAgent/LaunchControl.swift
@@ -67,6 +67,19 @@ public class LaunchControl {
 
     /// Writes a LaunchAgent to disk as a property list into the user's LaunchAgents directory
     ///
+    /// The agent's label will be used as the filename with a `.plist` extension.
+    ///
+    /// - Parameters:
+    ///   - agent: the agent to encode
+    /// - Throws: errors on encoding the property list
+    public func write(_ agent: LaunchAgent) throws {
+        let url = try launchAgentsURL().appendingPathComponent("\(agent.label).plist")
+        
+        try write(agent, to: url)
+    }
+    
+    /// Writes a LaunchAgent to disk as a property list into the user's LaunchAgents directory
+    ///
     /// - Parameters:
     ///   - agent: the agent to encode
     ///   - called: the file name of the job

--- a/Tests/LaunchAgentTests/LaunchControlTests.swift
+++ b/Tests/LaunchAgentTests/LaunchControlTests.swift
@@ -10,6 +10,13 @@ import XCTest
 
 class LaunchControlTests: XCTestCase {
 
+    func testWrite_withoutFilename() {
+        let agent = LaunchAgent(label: "TestAgent")
+        
+        XCTAssertNoThrow(try LaunchControl.shared.write(agent))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: agent.url!.path))
+    }
+
     func testWrite_withPlist() {
         let agent = LaunchAgent(label: "TestAgent")
         


### PR DESCRIPTION
The launch agents that I manage all use the agent's reverse-DNS-style label as the filename too, so I added a method that will do that without needing to pass the label as an argument. I think this is a reasonable default to provide but if not I'd understand if you didn't want to merge. Thanks for creating this library!