### PR TITLE
Add support for the new commands bootstrap and bootout

### DIFF
--- a/Sources/LaunchAgent/LaunchAgent+Status.swift
+++ b/Sources/LaunchAgent/LaunchAgent+Status.swift
@@ -66,6 +66,13 @@ extension LaunchAgent {
         try LaunchControl.shared.unload(self)
     }
     
+    /// Run `launchctl bootout` on the agent
+    ///
+    /// Check the status of the job with `.status()`
+    public func bootout() throws {
+        try LaunchControl.shared.bootout(self)
+    }
+    
     /// Retreives the status of the LaunchAgent from `launchctl`
     ///
     /// - Returns: the agent's status

--- a/Sources/LaunchAgent/LaunchAgent+Status.swift
+++ b/Sources/LaunchAgent/LaunchAgent+Status.swift
@@ -66,6 +66,13 @@ extension LaunchAgent {
         try LaunchControl.shared.unload(self)
     }
     
+    /// Run `launchctl bootstrap` on the agent
+    ///
+    /// Check the status of the job with `.status()`
+    public func bootstrap() throws {
+        try LaunchControl.shared.bootstrap(self)
+    }
+    
     /// Run `launchctl bootout` on the agent
     ///
     /// Check the status of the job with `.status()`

--- a/Sources/LaunchAgent/LaunchAgent+Status.swift
+++ b/Sources/LaunchAgent/LaunchAgent+Status.swift
@@ -69,6 +69,7 @@ extension LaunchAgent {
     /// Run `launchctl bootstrap` on the agent
     ///
     /// Check the status of the job with `.status()`
+    @available(macOS, introduced: 10.10)
     public func bootstrap() throws {
         try LaunchControl.shared.bootstrap(self)
     }
@@ -76,6 +77,7 @@ extension LaunchAgent {
     /// Run `launchctl bootout` on the agent
     ///
     /// Check the status of the job with `.status()`
+    @available(macOS, introduced: 10.10)
     public func bootout() throws {
         try LaunchControl.shared.bootout(self)
     }

--- a/Sources/LaunchAgent/LaunchAgent+Status.swift
+++ b/Sources/LaunchAgent/LaunchAgent+Status.swift
@@ -55,6 +55,7 @@ extension LaunchAgent {
     /// Run `launchctl load` on the agent
     ///
     /// Check the status of the job with `.status()`
+    @available(macOS, deprecated: 10.11)
     public func load() throws {
         try LaunchControl.shared.load(self)
     }
@@ -62,6 +63,7 @@ extension LaunchAgent {
     /// Run `launchctl unload` on the agent
     ///
     /// Check the status of the job with `.status()`
+    @available(macOS, deprecated: 10.11)
     public func unload() throws {
         try LaunchControl.shared.unload(self)
     }
@@ -69,7 +71,7 @@ extension LaunchAgent {
     /// Run `launchctl bootstrap` on the agent
     ///
     /// Check the status of the job with `.status()`
-    @available(macOS, introduced: 10.10)
+    @available(macOS, introduced: 10.11)
     public func bootstrap() throws {
         try LaunchControl.shared.bootstrap(self)
     }
@@ -77,7 +79,7 @@ extension LaunchAgent {
     /// Run `launchctl bootout` on the agent
     ///
     /// Check the status of the job with `.status()`
-    @available(macOS, introduced: 10.10)
+    @available(macOS, introduced: 10.11)
     public func bootout() throws {
         try LaunchControl.shared.bootout(self)
     }

--- a/Sources/LaunchAgent/LaunchControl.swift
+++ b/Sources/LaunchAgent/LaunchControl.swift
@@ -191,6 +191,7 @@ extension LaunchControl {
     /// Run `launchctl bootstrap` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
+    @available(macOS, introduced: 10.10)
     public func bootstrap(_ agent: LaunchAgent) throws {
         guard let agentURL = agent.url else {
             throw LaunchControlError.urlNotSet(label: agent.label)
@@ -203,6 +204,7 @@ extension LaunchControl {
     /// Run `launchctl bootout` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
+    @available(macOS, introduced: 10.10)
     public func bootout(_ agent: LaunchAgent) throws {        
         let arguments = ["bootout", "gui/\(uid)/\(agent.label)"]
         Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)

--- a/Sources/LaunchAgent/LaunchControl.swift
+++ b/Sources/LaunchAgent/LaunchControl.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SystemConfiguration
 
 /// Errors related to controlling jobs
 public enum LaunchControlError: Error, LocalizedError {
@@ -34,7 +35,12 @@ public class LaunchControl {
     let encoder = PropertyListEncoder()
     let decoder = PropertyListDecoder()
     
+    private var uid: uid_t = 0
+    private var gid: gid_t = 0
+    
     init() {
+        SCDynamicStoreCopyConsoleUser(nil, &uid, &gid)
+        
         encoder.outputFormat = .xml
     }
     
@@ -179,6 +185,14 @@ extension LaunchControl {
         }
         
         let arguments = ["unload", agentURL.path]
+        Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)
+    }
+    
+    /// Run `launchctl bootout` on the agent
+    ///
+    /// Check the status of the job with `.status(_: LaunchAgent)`
+    public func bootout(_ agent: LaunchAgent) throws {        
+        let arguments = ["bootout", "gui/\(uid)/\(agent.label)"]
         Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)
     }
     

--- a/Sources/LaunchAgent/LaunchControl.swift
+++ b/Sources/LaunchAgent/LaunchControl.swift
@@ -188,6 +188,18 @@ extension LaunchControl {
         Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)
     }
     
+    /// Run `launchctl bootstrap` on the agent
+    ///
+    /// Check the status of the job with `.status(_: LaunchAgent)`
+    public func bootstrap(_ agent: LaunchAgent) throws {
+        guard let agentURL = agent.url else {
+            throw LaunchControlError.urlNotSet(label: agent.label)
+        }
+        
+        let arguments = ["bootstrap", "gui/\(uid)", agentURL.path]
+        Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)
+    }
+    
     /// Run `launchctl bootout` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`

--- a/Sources/LaunchAgent/LaunchControl.swift
+++ b/Sources/LaunchAgent/LaunchControl.swift
@@ -167,6 +167,7 @@ extension LaunchControl {
     /// Run `launchctl load` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
+    @available(macOS, deprecated: 10.11)
     public func load(_ agent: LaunchAgent) throws {
         guard let agentURL = agent.url else {
             throw LaunchControlError.urlNotSet(label: agent.label)
@@ -179,6 +180,7 @@ extension LaunchControl {
     /// Run `launchctl unload` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
+    @available(macOS, deprecated: 10.11)
     public func unload(_ agent: LaunchAgent) throws {
         guard let agentURL = agent.url else {
             throw LaunchControlError.urlNotSet(label: agent.label)
@@ -191,7 +193,7 @@ extension LaunchControl {
     /// Run `launchctl bootstrap` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
-    @available(macOS, introduced: 10.10)
+    @available(macOS, introduced: 10.11)
     public func bootstrap(_ agent: LaunchAgent) throws {
         guard let agentURL = agent.url else {
             throw LaunchControlError.urlNotSet(label: agent.label)
@@ -204,7 +206,7 @@ extension LaunchControl {
     /// Run `launchctl bootout` on the agent
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
-    @available(macOS, introduced: 10.10)
+    @available(macOS, introduced: 10.11)
     public func bootout(_ agent: LaunchAgent) throws {        
         let arguments = ["bootout", "gui/\(uid)/\(agent.label)"]
         Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)

--- a/Sources/LaunchAgent/LaunchControl.swift
+++ b/Sources/LaunchAgent/LaunchControl.swift
@@ -207,8 +207,12 @@ extension LaunchControl {
     ///
     /// Check the status of the job with `.status(_: LaunchAgent)`
     @available(macOS, introduced: 10.11)
-    public func bootout(_ agent: LaunchAgent) throws {        
-        let arguments = ["bootout", "gui/\(uid)/\(agent.label)"]
+    public func bootout(_ agent: LaunchAgent) throws {
+        guard let agentURL = agent.url else {
+            throw LaunchControlError.urlNotSet(label: agent.label)
+        }
+        
+        let arguments = ["bootout", "gui/\(uid)", agentURL.path]
         Process.launchedProcess(launchPath: LaunchControl.launchctl, arguments: arguments)
     }
     

--- a/Tests/LaunchAgentTests/LaunchControlTests.swift
+++ b/Tests/LaunchAgentTests/LaunchControlTests.swift
@@ -90,6 +90,32 @@ class LaunchControlTests: XCTestCase {
         XCTAssertThrowsError(try LaunchControl.shared.unload(testAgent))
     }
     
+    func testBootstrap() {
+        XCTAssertNoThrow(try LaunchControl.shared.bootstrap(agent))
+        sleep(1)
+        
+        XCTAssertEqual(agent.status(), AgentStatus.loaded)
+    }
+    
+    func testBootstrapError() {
+        let testAgent = LaunchAgent(label: "TestAgent")
+        XCTAssertThrowsError(try LaunchControl.shared.bootstrap(testAgent))
+    }
+    
+    func testBootout() {
+        XCTAssertNoThrow(try LaunchControl.shared.load(agent))
+        sleep(1)
+        XCTAssertNoThrow(try LaunchControl.shared.bootout(agent))
+        sleep(1)
+        
+        XCTAssertEqual(agent.status(), AgentStatus.unloaded)
+    }
+    
+    func testBootoutError() {
+        let testAgent = LaunchAgent(label: "TestAgent")
+        XCTAssertThrowsError(try LaunchControl.shared.bootout(testAgent))
+    }
+    
     func testStartStop() {
         XCTAssertNoThrow(try LaunchControl.shared.load(agent))
         sleep(1)


### PR DESCRIPTION
Bootstrap and bootout were introduced in 10.10 and load and unload were deprecated. You can read about it here. https://babodee.wordpress.com/2016/04/09/launchctl-2-0-syntax/